### PR TITLE
add plugin chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Available Commands:
 
 Flags:
   -p, --plugin string        The name of the plugin to use (default "openai")
+  -P, --choose-plugin        Choose the plugin to use
   -m, --model string         The name of the model to use
-  -c, --choose-model         Choose the model to use
+  -M, --choose-model         Choose the model to use
   -t, --temperature string   The temperature to use
   -r, --role string          The role to use
       --raw                  Raw output without formatting

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ type Task struct {
 
 const (
 	configFileName = "config.yaml"
-	version        = "0.1.5"
+	version        = "0.1.6"
 )
 
 var (


### PR DESCRIPTION
add new `-P`, `--choose-plugin` flag.  allows user to select from a list of available plugins, as defined in the configuration file.  

```txt
A WASM plug-in based CLI for AI chat completions

Usage:
  assembllm [prompt] [flags]
  assembllm [command]

Available Commands:
  tasks       LLM prompt chaining for complex tasks.

Flags:
  -p, --plugin string        The name of the plugin to use (default "openai")
  -P, --choose-plugin        Choose the plugin to use
  -m, --model string         The name of the model to use
  -M, --choose-model         Choose the model to use
  -t, --temperature string   The temperature to use
  -r, --role string          The role to use
      --raw                  Raw output without formatting
  -v, --version              Print the version
  -h, --help                 help for assembllm

Use "assembllm [command] --help" for more information about a command.
```

Additionally, deprecated `-c` shorthand flag for `--choose-model` to `-M.`