### PR TITLE
fix: error handling openai rust plugin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 completion-plugins:
   - name: openai
-    source: https://cdn.modsurfer.dylibso.com/api/v1/module/114e1e892c43baefb4d50cc8b0e9f66df2b2e3177de9293ffdd83898c77e04c7.wasm
-    hash: 114e1e892c43baefb4d50cc8b0e9f66df2b2e3177de9293ffdd83898c77e04c7
+    source: https://cdn.modsurfer.dylibso.com/api/v1/module/e5768c2835a01ee1a5f10702020a82e0ba2166ba114733e2215b2c2ef423985f.wasm
+    hash: e5768c2835a01ee1a5f10702020a82e0ba2166ba114733e2215b2c2ef423985f
     apiKey: OPENAI_API_KEY
     url: api.openai.com
     model: 4o

--- a/plugins/openai-completions-rust/src/lib.rs
+++ b/plugins/openai-completions-rust/src/lib.rs
@@ -97,10 +97,24 @@ fn get_completion(
     });
 
     let res = http::request::<String>(&req, Some(req_body.to_string()))?;
-    let body = res.body();
-    let body = from_utf8(&body)?;
-    let body: ChatResult = serde_json::from_str(body)?;
-    Ok(body)
+    match res.status_code() {
+        200 => {
+            info!("Request successful");
+        }
+        _ => {
+            let response_body = res.body();
+            let body = from_utf8(&response_body)?;
+            return Err(anyhow::anyhow!(
+                "error calling API\nStatus Code: {}\n Response: {}",
+                res.status_code(),
+                body
+            ));
+        }
+    }
+    let response_body = res.body();
+    let body = from_utf8(&response_body)?;
+    let chat_result: ChatResult = serde_json::from_str(body)?;
+    Ok(chat_result)
 }
 
 fn get_config_values(


### PR DESCRIPTION
The default plug-in, OpenAI rust, lacked proper API error handling, resulting in confusing output when issues like a bad API key were being used #19 :

```sh
assembllm hello
failed to get completion: missing field `choices` at line 8 column 1
```

This update properly handles the API errors:

```sh
assembllm hello           
failed to get completion: error calling API
Status Code: 401
 Response: {
    "error": {
        "message": "Incorrect API key provided: x. You can find your API key at https://platform.openai.com/account/api-keys.",
        "type": "invalid_request_error",
        "param": null,
        "code": "invalid_api_key"
    }
}
```

In addition to fixing the plug-in this introduces a crude plug-in updater implementation that checks the existing app config for old versions of built-in plug-ins and updates them to the latest version, where appropriate, while leaving other aspects of the config file unmodified.