### PR TITLE
chore: improve RSS and article summarization

### DIFF
--- a/workflows/article_summarizer.yaml
+++ b/workflows/article_summarizer.yaml
@@ -1,0 +1,21 @@
+name: article summary and analysis
+description: |
+  Optimized for taking an article's title and URL as a prompt and providing an 
+  effective summary using Perplexity's Online model, which contains up to date 
+  information.
+
+tasks:
+  - plugin: perplexity
+    prompt: |
+      # Task Objective
+
+      Give a detailed analysis of the topic supported by a URL source provided.
+      Provide references, if available.  Include the URL provided at the end of
+      the summary.  Response must be 250 words or less.
+
+      ## Task Details
+
+      Be insightful. Think about the author's claims deeply and express the strengths
+      and weaknesses of their argument.  Where practical, think about how the topic
+      can impact a person's daily life, or an industry long-term, or is it just
+      passing information with little impact.

--- a/workflows/rss.yaml
+++ b/workflows/rss.yaml
@@ -1,15 +1,19 @@
-name: Hacker News Top Story Workflow
+name: RSS Article Summarizer
 description: |
-  This workflow calls the RSS feed for hacker news, obtains the title and url of
-  the first 5 stories in the feed, and sends them on by one to Perplexity's online
-  model which has up to date information.  The model provides a summary and
-  insight for each.  
+  This workflow calls an RSS feed sent in as a prompt, obtains the title and url of
+  the first 5 stories in the feed, and sends calls an external workflow that provides
+  a summary.  Then an post script adds output formatting by adding the title from the
+  rss feed as a markdown header above the response.
 
-  Requires version 0.4.0 or later of the assembllm plugin.
-iterator_script: >
-  let rss = Get('https://news.ycombinator.com/rss');
-  split(rss, "<item>")[1:] 
-  | map(
+iterator_script: |
+  // Fetch the RSS feed
+  let rss = Get(input);
+
+  // Split the feed into items
+  let items = split(rss, "<item>")[1:];
+
+  // Get the titles and links from the items as 'TITLE --- URL'
+  let titlesAndLinks = items | map(
       join(
         split(#, "<title>") 
         | last()
@@ -19,31 +23,21 @@ iterator_script: >
           | last() + " --- "
           | split("</link>") 
           | first()
-        )
-      )
-    )
-  | take(5)
+       )
+     )
+  );
+
+  // Take the first 5
+  let top5 = titlesAndLinks | take(5);
+
+  // Output the top 5
+  top5
 
 tasks:
-  - name: topic
-    plugin: perplexity
-    prompt: |
-      # Task Objective
+  - post_script: |
+      // Call an article summarization workflow.
+      let res = Workflow("./workflows/article_summary.yaml", iterValue);
 
-      Give a detailed analysis of the topic supported by a URL source provided.
-      Provide references, if available.  Include the URL provided at the end of
-      the summary.  Response must be 250 words or less.
-
-      ## Task Details
-
-      Be insightful. Think about the author's claims deeply and express the strengths
-      and weaknesses of their argument.  Where practical, think about how the topic
-      can impact a person's daily life, or an industry long-term, or is it just
-      passing information with little impact.
-    post_script: |
-      //
-      // Get the title from the rss feed input and add it to the top of the output
-      // as a markdown header.
-      //
+      // Current iterValue is retained across tasks.  We use it to form a summary header.
       let title = split(iterValue, "---") | first();
-      "# " + title + "\n" + input
+      "# " + title + "\n" + res


### PR DESCRIPTION
Updated the RSS workflow to be dynamic instead of hard-coded to an RSS URL.  Now you can send a URL as a parameter and get summaries based on the feed.

Additionally, moved the article summarization process to its own workflow for modularity and reuse.  The RSS workflow calls the separate summarizer workflow to obtain summaries.